### PR TITLE
add onEdit and onCancel event

### DIFF
--- a/src/inline-editor.component.ts
+++ b/src/inline-editor.component.ts
@@ -148,6 +148,8 @@ export class InlineEditorComponent implements ControlValueAccessor, OnInit, Inpu
     // inline edit form control
     @ViewChild('inlineEditControl') inlineEditControl;
     @Output() public onSave: EventEmitter<any> = new EventEmitter();
+    @Output() public onEdit: EventEmitter<any> = new EventEmitter();
+    @Output() public onCancel: EventEmitter<any> = new EventEmitter();
 
     //Configuration attribute 
     @Input() empty: string;
@@ -285,6 +287,8 @@ export class InlineEditorComponent implements ControlValueAccessor, OnInit, Inpu
         this.editing = true;
         // Automatically focus input
         setTimeout(_ => this._renderer.invokeElementMethod(this.inlineEditControl.nativeElement, 'focus', []));
+
+        this.onEdit.emit(value);
     }
 
     // Method to display the editable value as text and emit save event to host
@@ -306,6 +310,8 @@ export class InlineEditorComponent implements ControlValueAccessor, OnInit, Inpu
     cancel(value: any) {
         this._value = this.preValue;
         this.editing = false;
+        
+        this.onCancel.emit(value);
     }
 
 }

--- a/src/inline-editor.component.ts
+++ b/src/inline-editor.component.ts
@@ -288,7 +288,7 @@ export class InlineEditorComponent implements ControlValueAccessor, OnInit, Inpu
         // Automatically focus input
         setTimeout(_ => this._renderer.invokeElementMethod(this.inlineEditControl.nativeElement, 'focus', []));
 
-        this.onEdit.emit(value);
+        this.onEdit.emit(this);
     }
 
     // Method to display the editable value as text and emit save event to host
@@ -311,7 +311,7 @@ export class InlineEditorComponent implements ControlValueAccessor, OnInit, Inpu
         this._value = this.preValue;
         this.editing = false;
         
-        this.onCancel.emit(value);
+        this.onCancel.emit(this);
     }
 
 }


### PR DESCRIPTION
The onEdit event gets emit when the editing starts and the onCancel events gets emit when the editing is canceled.

This is e.g. useful if only one editing element should be active and you have multiple elements on the page. 