### PR TITLE
added custom template case option (using ng-content)

### DIFF
--- a/src/inline-editor.component.ts
+++ b/src/inline-editor.component.ts
@@ -50,6 +50,9 @@ const INLINE_EDITOR_TEMPLATE = `
           <a [ngClass]="{'editable-empty': isEmpty }"
             (click)="edit(value)" [hidden]="editing"> {{optionSelected()}} </a>
         </template>
+        <template [ngSwitchCase]="'custom'">
+            <a [ngClass]="{'editable-empty': isEmpty }" (click)="edit(value)" [hidden]="editing" [innerHTML]="showText()"></a>
+        </template>
         <template ngSwitchDefault>
             <a [ngClass]="{'editable-empty': isEmpty }"  (click)="edit(value)" [hidden]="editing">{{ showText() }}</a>
         </template>
@@ -85,6 +88,9 @@ const INLINE_EDITOR_TEMPLATE = `
                      <option *ngIf="!item.children" value="{{item[options.value]}}">{{item[options.text]}}</option>
                     </template>
                     </select>
+                </template>
+                <template [ngSwitchCase]="'custom'">
+                    <ng-content #inlineEditControl class="form-control" select="div"></ng-content>
                 </template>
                 <template ngSwitchDefault>
                     <input [type]="type"  #inlineEditControl class="form-control" [(ngModel)]="value"


### PR DESCRIPTION
When you need a dynamic content inside the inline editor you can now use ```type='custom'``` as a value to the ```type``` input argument.
I'm using it to display a rich-text editor like [ngx-quill](https://github.com/KillerCodeMonkey/ngx-quill).

example:
```
<inline-editor type="custom" [(ngModel)]="value" name="editableText1">
  <div>
    <quill-editor [(ngModel)]="value"></quill-editor>
  </div>
</inline-editor>
```