### PR TITLE
fix(InlineEditorComponent): Add posibility of pass an array as options

### DIFF
--- a/src/inline-editor.component.ts
+++ b/src/inline-editor.component.ts
@@ -63,29 +63,7 @@ const inputConfig: InputConfig = {
     entryComponents: InputComponets,
 })
 export class InlineEditorComponent implements OnInit, ControlValueAccessor {
-
-    // Inputs implemented
-    private components: { [key: string]: any } = {
-        text: InputTextComponent,
-        number: InputNumberComponent,
-        password: InputPasswordComponent,
-        range: InputRangeComponent,
-        textarea: InputTextareaComponent,
-        select: InputSelectComponent,
-        date: InputDateComponent,
-        time: InputTimeComponent,
-        datetime: InputDateTimeComponent,
-    };
-
-    private getComponentType(typeName: InputType): any {
-        const type = this.components[typeName];
-
-        if (!type) {
-            throw new Error("That type does not exist or it is not implemented yet!");
-        }
-
-        return type;
-    }
+    constructor(public componentFactoryResolver: ComponentFactoryResolver) { }
 
     @Input() public type: InputType;
 
@@ -112,7 +90,18 @@ export class InlineEditorComponent implements OnInit, ControlValueAccessor {
     // textarea's attribute
     @Input() public cols = 50;
     @Input() public rows = 4;
-    @Input() public options: SelectOptions;
+
+    @Input()
+    set options(options: SelectOptions) {
+        this._options = options instanceof Array ?
+            {
+                data: options,
+                value: "value",
+                text: "text",
+            } : options;
+    }
+
+    get options() { return this._options; }
 
     // select's attribute
 
@@ -121,10 +110,11 @@ export class InlineEditorComponent implements OnInit, ControlValueAccessor {
     public onChange: Function;
     public onTouched: Function;
 
-    private _value = "";
-    private preValue = "";
     public editing = false;
     public isEmpty = false;
+    private _options: SelectOptions;
+    private _value = "";
+    private preValue = "";
 
     public get value(): any { return this._value; };
 
@@ -135,7 +125,6 @@ export class InlineEditorComponent implements OnInit, ControlValueAccessor {
         }
     }
 
-    constructor(public componentFactoryResolver: ComponentFactoryResolver) { }
 
     private componentRef: ComponentRef<{}>;
 
@@ -143,6 +132,29 @@ export class InlineEditorComponent implements OnInit, ControlValueAccessor {
     private container: ViewContainerRef;
     private inputInstance: InputBase;
 
+
+
+    // Inputs implemented
+    private components: { [key: string]: any } = {
+        text: InputTextComponent,
+        number: InputNumberComponent,
+        password: InputPasswordComponent,
+        range: InputRangeComponent,
+        textarea: InputTextareaComponent,
+        select: InputSelectComponent,
+        date: InputDateComponent,
+        time: InputTimeComponent,
+        datetime: InputDateTimeComponent,
+    };
+    private getComponentType(typeName: InputType): any {
+        const type = this.components[typeName];
+
+        if (!type) {
+            throw new Error("That type does not exist or it is not implemented yet!");
+        }
+
+        return type;
+    }
     ngOnInit() {
         if (this.type) {
             this.initializeProperties();
@@ -179,16 +191,11 @@ export class InlineEditorComponent implements OnInit, ControlValueAccessor {
     }
 
     writeValue(value: any) {
-        if (value || value === 0) {
+        if (value == null) {
+            this.isEmpty = true;
+        } else {
             this.value = value;
             this.isEmpty = false;
-        } else {
-
-            /*if (this.type === "select") {
-                this.empty = this.options.data[0][this.options.value];
-            }*/
-            // this._value = this.empty;
-            this.isEmpty = true;
         }
     }
 

--- a/src/inputs/input-select.component.ts
+++ b/src/inputs/input-select.component.ts
@@ -20,10 +20,10 @@ import { SelectOptionWithChildren } from "../input-config";
 })
 export class InputSelectComponent extends InputBase implements OnInit {
     @ViewChild("inputRef") public inputRef: ElementRef;
-
     constructor(renderer: Renderer) {
         super(renderer);
     }
+
 
     public getPlaceholder(): string {
         return this.optionSelected();
@@ -58,7 +58,8 @@ export class InputSelectComponent extends InputBase implements OnInit {
                 }
             }
         } else {
-            if (options[value] === this.context.value) {
+            // tslint:disable-next-line:triple-equals
+            if (options[value] == this.context.value) {
                 textOfSelectedOption = options[text];
             }
         }

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -7,6 +7,7 @@
     "stripInternal": true,
     "outDir": "../build",
     "rootDir": ".",
+    // "sourceMap": true,
     "lib": [
       "es2015",
       "dom"

--- a/tslint.json
+++ b/tslint.json
@@ -27,8 +27,22 @@
     "member-access": false,
     "member-ordering": [
       true,
-      "static-before-instance",
-      "variables-before-functions"
+      {
+        "order": [
+          "public-constructor",
+          "protected-constructor",
+          "private-constructor",
+          "public-instance-field",
+          "protected-instance-field",
+          "private-instance-field",
+          "public-static-field",
+          "protected-static-field",
+          "public-instance-method",
+          "protected-instance-method",
+          "public-static-method",
+          "protected-static-method"
+        ]
+      }
     ],
     "no-arg": true,
     "no-bitwise": true,


### PR DESCRIPTION
This behavior was deleted in https://github.com/Caballerog/ng2-inline-editor/pull/48

By default it will transform array to SelectOptions ({data: <arrayPassed>, text: "text", value:
"value"})

Redefined member-ordering TSLint rule